### PR TITLE
Allow access beyond 1 day default, up to 7

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -14,6 +14,7 @@ export const config: Config = {
       attribute: "custom:accessbotTest",
       description: "Accessbot Test: Select Users",
       canSelfApprove: true,
+      maxSeconds: 3 * 86400, // 3 days.
       approverEmails: [
         // Enter some email addresses here.
         "someone@example.com",
@@ -49,7 +50,7 @@ export type Profile = {
   /**
    * The maximum duration to offer the user when they are requesting access to
    * this profile.
-   * @default undefined (meaning offer all preset durations to the user)
+   * @default 86400 (1 day, can be increased to 7*86400 for 7 days)
    */
   maxSeconds?: number;
   /**

--- a/functions/access_request_prompt.ts
+++ b/functions/access_request_prompt.ts
@@ -361,7 +361,8 @@ function formState(state: any): FormState {
 }
 
 const minuteSecs = 60;
-const hourSecs = 60 * 60;
+const hourSecs = 60 * minuteSecs;
+const daySecs = 24 * hourSecs;
 
 export const presetDurations = [
   { text: "5 minutes", seconds: 5 * minuteSecs },
@@ -370,7 +371,13 @@ export const presetDurations = [
   { text: "4 hours", seconds: 4 * hourSecs },
   { text: "8 hours", seconds: 8 * hourSecs },
   { text: "12 hours", seconds: 12 * hourSecs },
-  { text: "24 hours", seconds: 24 * hourSecs },
+  { text: "24 hours", seconds: 1 * daySecs },
+  { text: "2 days", seconds: 2 * daySecs },
+  { text: "3 days", seconds: 3 * daySecs },
+  { text: "4 days", seconds: 4 * daySecs },
+  { text: "5 days", seconds: 5 * daySecs },
+  { text: "6 days", seconds: 6 * daySecs },
+  { text: "7 days", seconds: 7 * daySecs },
 ];
 
 async function buildView(
@@ -394,14 +401,13 @@ async function buildView(
     },
   }));
 
-  let durations = presetDurations;
-  if (profile && profile.maxSeconds) {
-    durations = durations.filter((d) => d.seconds <= profile.maxSeconds!);
-  }
-  const durationOpts = durations.map((d) => ({
-    text: { type: "plain_text", text: d.text },
-    value: d.seconds.toFixed(0),
-  }));
+  const maxSeconds = profile?.maxSeconds || daySecs;
+  const durationOpts = presetDurations
+    .filter((d) => d.seconds <= maxSeconds)
+    .map((d) => ({
+      text: { type: "plain_text", text: d.text },
+      value: d.seconds.toFixed(0),
+    }));
   state.duration ||= durationOpts[0].value;
 
   return {


### PR DESCRIPTION
Here's a screenshot for the example config where maxSeconds is omitted. The default remains 24 hours.

![Screenshot 2024-10-25 at 00 25 39@2x](https://github.com/user-attachments/assets/97df7939-d958-4321-ae33-051a60e4021f)

We can set maxSeconds to 3*86400 to see 3 days (works up to 7 days):

![Screenshot 2024-10-25 at 00 26 29@2x](https://github.com/user-attachments/assets/c8893603-2953-4535-ba28-1160cc6a2474)
